### PR TITLE
feat: stop command support windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 deploy tool for egg project.
 
-**Note: Windows is not supported**
+**Note: Windows is partially supported, see [#22](https://github.com/eggjs/egg-scripts/pull/22)**
 
 ## Install
 

--- a/lib/cmd/stop.js
+++ b/lib/cmd/stop.js
@@ -3,6 +3,12 @@
 const path = require('path');
 const sleep = require('mz-modules/sleep');
 const Command = require('../command');
+const isWin = process.platform === 'win32';
+const osRelated = {
+  titlePrefix: isWin ? '\\"title\\":\\"' : '"title":"',
+  appWorkerPath: isWin ? 'egg-cluster\\lib\\app_worker.js' : 'egg-cluster/lib/app_worker.js',
+  agentWorkerPath: isWin ? 'egg-cluster\\lib\\agent_worker.js' : 'egg-cluster/lib/agent_worker.js',
+};
 
 class StopCommand extends Command {
 
@@ -23,12 +29,6 @@ class StopCommand extends Command {
   }
 
   * run(context) {
-    /* istanbul ignore next */
-    if (process.platform === 'win32') {
-      this.logger.warn('Windows is not supported, try to kill master process which command contains `start-cluster` or `--type=egg-server` yourself, good luck.');
-      process.exit(0);
-    }
-
     const { argv } = context;
 
     this.logger.info(`stopping egg application ${argv.title ? `with --title=${argv.title}` : ''}`);
@@ -37,7 +37,7 @@ class StopCommand extends Command {
     let processList = yield this.helper.findNodeProcess(item => {
       const cmd = item.cmd;
       return argv.title ?
-        cmd.includes('start-cluster') && cmd.includes(`"title":"${argv.title}"`) :
+        cmd.includes('start-cluster') && cmd.includes(`${osRelated.titlePrefix}${argv.title}`) :
         cmd.includes('start-cluster');
     });
     let pids = processList.map(x => x.pid);
@@ -57,8 +57,8 @@ class StopCommand extends Command {
     processList = yield this.helper.findNodeProcess(item => {
       const cmd = item.cmd;
       return argv.title ?
-        (cmd.includes('egg-cluster/lib/app_worker.js') || cmd.includes('egg-cluster/lib/agent_worker.js')) && cmd.includes(`"title":"${argv.title}"`) :
-        (cmd.includes('egg-cluster/lib/app_worker.js') || cmd.includes('egg-cluster/lib/agent_worker.js'));
+        (cmd.includes(osRelated.appWorkerPath) || cmd.includes(osRelated.agentWorkerPath)) && cmd.includes(`${osRelated.titlePrefix}${argv.title}`) :
+        (cmd.includes(osRelated.appWorkerPath) || cmd.includes(osRelated.agentWorkerPath));
     });
     pids = processList.map(x => x.pid);
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -2,12 +2,12 @@
 
 const runScript = require('runscript');
 const isWin = process.platform === 'win32';
-const REGEX = /^(.*)\s+(\d+)\s*$/;
+const REGEX = isWin ? /^(.*)\s+(\d+)\s*$/ : /^\s*(\d+)\s+(.*)/;
 
 exports.findNodeProcess = function* (filterFn) {
   const command = isWin ?
     'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId' :
-    'ps -eo "command,pid"';
+    'ps -eo "pid,command"';
   const stdio = yield runScript(command, { stdio: 'pipe' });
   const processList = stdio.stdout.toString().split('\n')
     .reduce((arr, line) => {
@@ -15,7 +15,7 @@ exports.findNodeProcess = function* (filterFn) {
         const m = line.match(REGEX);
         /* istanbul ignore else */
         if (m) {
-          const item = { pid: m[2], cmd: m[1] };
+          const item = isWin ? { pid: m[2], cmd: m[1] } : { pid: m[1], cmd: m[2] };
           if (!filterFn || filterFn(item)) {
             arr.push(item);
           }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,10 +1,13 @@
 'use strict';
 
 const runScript = require('runscript');
-const REGEX = /^\s*(\d+)\s+(.*)/;
+const isWin = process.platform === 'win32';
+const REGEX = isWin ? /^(.*)\s+(\d+)\s+$/ : /^\s*(\d+)\s+(.*)/;
 
 exports.findNodeProcess = function* (filterFn) {
-  const command = 'ps -eo "pid,command"';
+  const command = isWin ?
+    'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId' :
+    'ps -eo "pid,command"';
   const stdio = yield runScript(command, { stdio: 'pipe' });
   const processList = stdio.stdout.toString().split('\n')
     .reduce((arr, line) => {
@@ -12,7 +15,7 @@ exports.findNodeProcess = function* (filterFn) {
         const m = line.match(REGEX);
         /* istanbul ignore else */
         if (m) {
-          const item = { pid: m[1], cmd: m[2] };
+          const item = isWin ? { pid: m[2], cmd: m[1] } : { pid: m[1], cmd: m[2] };
           if (!filterFn || filterFn(item)) {
             arr.push(item);
           }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -2,12 +2,12 @@
 
 const runScript = require('runscript');
 const isWin = process.platform === 'win32';
-const REGEX = isWin ? /^(.*)\s+(\d+)\s+$/ : /^\s*(\d+)\s+(.*)/;
+const REGEX = /^(.*)\s+(\d+)\s*$/;
 
 exports.findNodeProcess = function* (filterFn) {
   const command = isWin ?
     'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId' :
-    'ps -eo "pid,command"';
+    'ps -eo "command,pid"';
   const stdio = yield runScript(command, { stdio: 'pipe' });
   const processList = stdio.stdout.toString().split('\n')
     .reduce((arr, line) => {
@@ -15,7 +15,7 @@ exports.findNodeProcess = function* (filterFn) {
         const m = line.match(REGEX);
         /* istanbul ignore else */
         if (m) {
-          const item = isWin ? { pid: m[2], cmd: m[1] } : { pid: m[1], cmd: m[2] };
+          const item = { pid: m[2], cmd: m[1] };
           if (!filterFn || filterFn(item)) {
             arr.push(item);
           }

--- a/test/fixtures/ts-pkg/package.json
+++ b/test/fixtures/ts-pkg/package.json
@@ -8,6 +8,7 @@
     "typescript": true
   },
   "scripts": {
-    "build": "node ../../../node_modules/.bin/tsc"
+    "build": "node ../../../node_modules/.bin/tsc",
+    "windows-build": "call ../../../node_modules/.bin/tsc.cmd"
   }
 }

--- a/test/fixtures/ts/package.json
+++ b/test/fixtures/ts/package.json
@@ -5,6 +5,7 @@
     "egg": "^1.0.0"
   },
   "scripts": {
-    "build": "node ../../../node_modules/.bin/tsc"
+    "build": "node ../../../node_modules/.bin/tsc",
+    "windows-build": "call ../../../node_modules/.bin/tsc.cmd"
   }
 }

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -10,6 +10,7 @@ const coffee = require('coffee');
 const httpclient = require('urllib');
 const mm = require('mm');
 const utils = require('./utils');
+const isWin = process.platform === 'win32';
 
 describe('test/start.test.js', () => {
   const eggBin = require.resolve('../bin/egg-scripts.js');
@@ -271,7 +272,8 @@ describe('test/start.test.js', () => {
         let result = yield httpclient.request('http://127.0.0.1:7001/env');
         assert(result.data.toString() === 'pre, true');
         result = yield httpclient.request('http://127.0.0.1:7001/path');
-        assert(result.data.toString().match(new RegExp(`^${fixturePath}/node_modules/.bin${path.delimiter}`)));
+        const appBinPath = path.join(fixturePath, 'node_modules/.bin');
+        assert(result.data.toString().startsWith(`${appBinPath}${path.delimiter}`));
       });
     });
 
@@ -402,7 +404,7 @@ describe('test/start.test.js', () => {
   describe('start with daemon', () => {
     let cwd;
     beforeEach(function* () {
-      yield utils.cleanup(cwd);
+      if (cwd) yield utils.cleanup(cwd);
       yield rimraf(logDir);
       yield mkdirp(logDir);
       yield fs.writeFile(path.join(logDir, 'master-stdout.log'), 'just for test');
@@ -410,7 +412,7 @@ describe('test/start.test.js', () => {
     });
     afterEach(function* () {
       yield coffee.fork(eggBin, [ 'stop', cwd ])
-        // .debug()
+      // .debug()
         .end();
       yield utils.cleanup(cwd);
     });
@@ -418,7 +420,7 @@ describe('test/start.test.js', () => {
     it('should start custom-framework', function* () {
       cwd = fixturePath;
       yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', '--port=7002', cwd ])
-        // .debug()
+      // .debug()
         .expect('stdout', /Starting custom-framework application/)
         .expect('stdout', /custom-framework started on http:\/\/127\.0\.0\.1:7002/)
         .expect('code', 0)
@@ -442,7 +444,7 @@ describe('test/start.test.js', () => {
     it('should start default egg', function* () {
       cwd = path.join(__dirname, 'fixtures/egg-app');
       yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', cwd ])
-        // .debug()
+      // .debug()
         .expect('stdout', /Starting egg application/)
         .expect('stdout', /egg started on http:\/\/127\.0\.0\.1:7001/)
         .expect('code', 0)
@@ -455,7 +457,7 @@ describe('test/start.test.js', () => {
 
     after(function* () {
       yield coffee.fork(eggBin, [ 'stop', cwd ])
-        // .debug()
+      // .debug()
         .end();
       yield utils.cleanup(cwd);
     });
@@ -463,7 +465,7 @@ describe('test/start.test.js', () => {
     it('should status check success, exit with 0', function* () {
       mm(process.env, 'WAIT_TIME', 5000);
       yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1' ], { cwd })
-        // .debug()
+      // .debug()
         .expect('stdout', /Wait Start: 5.../)
         .expect('stdout', /custom-framework started/)
         .expect('code', 0)
@@ -474,12 +476,14 @@ describe('test/start.test.js', () => {
       mm(process.env, 'WAIT_TIME', 5000);
       mm(process.env, 'ERROR', 'error message');
 
-      const stderr = path.join(homePath, 'logs/master-stderr.log');
+      let stderr = path.join(homePath, 'logs/master-stderr.log');
+      if (isWin) stderr = stderr.replace(/\\/g, '\\\\');
 
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1', '--ignore-stderr' ], { cwd })
-        // .debug()
-        .expect('stderr', /nodejs.Error: error message/)
-        .expect('stderr', new RegExp(`Start got error, see ${stderr}`))
+      const app = coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1', '--ignore-stderr' ], { cwd });
+      // app.debug();
+      // TODO: find a windows replacement for tail command
+      if (!isWin) app.expect('stderr', /nodejs.Error: error message/);
+      yield app.expect('stderr', new RegExp(`Start got error, see ${stderr}`))
         .expect('code', 0)
         .end();
     });
@@ -488,12 +492,14 @@ describe('test/start.test.js', () => {
       mm(process.env, 'WAIT_TIME', 5000);
       mm(process.env, 'ERROR', 'error message');
 
-      const stderr = path.join(homePath, 'logs/master-stderr.log');
+      let stderr = path.join(homePath, 'logs/master-stderr.log');
+      if (isWin) stderr = stderr.replace(/\\/g, '\\\\');
 
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1' ], { cwd })
-        // .debug()
-        .expect('stderr', /nodejs.Error: error message/)
-        .expect('stderr', new RegExp(`Start got error, see ${stderr}`))
+      const app = coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1' ], { cwd });
+      // app.debug()
+      // TODO: find a windows replacement for tail command
+      if (!isWin) app.expect('stderr', /nodejs.Error: error message/);
+      yield app.expect('stderr', new RegExp(`Start got error, see ${stderr}`))
         .expect('code', 1)
         .end();
     });
@@ -502,7 +508,7 @@ describe('test/start.test.js', () => {
       mm(process.env, 'WAIT_TIME', 10000);
 
       yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1', '--timeout=5000' ], { cwd })
-        // .debug()
+      // .debug()
         .expect('stdout', /Wait Start: 1.../)
         .expect('stderr', /Start failed, 5s timeout/)
         .expect('code', 1)

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -10,6 +10,7 @@ const coffee = require('coffee');
 const httpclient = require('urllib');
 const mm = require('mm');
 const utils = require('./utils');
+const isWin = process.platform === 'win32';
 
 describe('test/ts.test.js', () => {
   const eggBin = require.resolve('../bin/egg-scripts.js');
@@ -28,7 +29,7 @@ describe('test/ts.test.js', () => {
     beforeEach(function* () {
       fixturePath = path.join(__dirname, 'fixtures/ts');
       yield utils.cleanup(fixturePath);
-      const result = cp.spawnSync('npm', [ 'run', 'build' ], { cwd: fixturePath });
+      const result = cp.spawnSync('npm', [ 'run', isWin ? 'windows-build' : 'build' ], { cwd: fixturePath, shell: isWin });
       assert(!result.stderr.toString());
     });
 
@@ -48,7 +49,7 @@ describe('test/ts.test.js', () => {
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
       const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
-      assert(result.data.stack.includes('app/controller/home.ts:6:13'));
+      assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
 
     it('--typescript', function* () {
@@ -62,7 +63,7 @@ describe('test/ts.test.js', () => {
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
       const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
-      assert(result.data.stack.includes('app/controller/home.ts:6:13'));
+      assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
 
     it('--sourcemap', function* () {
@@ -76,7 +77,7 @@ describe('test/ts.test.js', () => {
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
       const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
-      assert(result.data.stack.includes('app/controller/home.ts:6:13'));
+      assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
   });
 
@@ -85,7 +86,7 @@ describe('test/ts.test.js', () => {
     beforeEach(function* () {
       fixturePath = path.join(__dirname, 'fixtures/ts-pkg');
       yield utils.cleanup(fixturePath);
-      const result = cp.spawnSync('npm', [ 'run', 'build' ], { cwd: fixturePath });
+      const result = cp.spawnSync('npm', [ 'run', isWin ? 'windows-build' : 'build' ], { cwd: fixturePath, shell: isWin });
       assert(!result.stderr.toString());
     });
 
@@ -105,7 +106,7 @@ describe('test/ts.test.js', () => {
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
       const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
-      assert(result.data.stack.includes('app/controller/home.ts:6:13'));
+      assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,9 +2,14 @@
 
 const helper = require('../lib/helper');
 const sleep = require('mz-modules/sleep');
+const isWin = process.platform === 'win32';
 
 exports.cleanup = function* (baseDir) {
-  const processList = yield helper.findNodeProcess(x => x.cmd.includes(`"baseDir":"${baseDir}"`));
+  const processList = yield helper.findNodeProcess(x => {
+    const dir = isWin ? baseDir.replace(/\\/g, '\\\\') : baseDir;
+    const prefix = isWin ? '\\"baseDir\\":\\"' : '"baseDir":"';
+    return x.cmd.includes(`${prefix}${dir}`);
+  });
 
   if (processList.length) {
     console.log(`cleanup: ${processList.length} to kill`);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

`stop` command supports windows now.

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adjust find process command and filter logic to support windows, done simple than other pr.

Tested on Windows 7 and Windows 10, works fine.

By the way, the `npm run test` wouldn't pass even if I don't change anything, which I didn't dig in.
