### PR TITLE
refactor: add `this.exit` to instead of `process.exit`

### DIFF
--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -72,6 +72,10 @@ class StartCommand extends Command {
     return 'Start server at prod mode';
   }
 
+  exit(code) {
+    process.exit(code);
+  }
+
   * run(context) {
     const { argv, env, cwd, execArgv } = context;
 
@@ -156,7 +160,7 @@ class StartCommand extends Command {
           this.logger.info('%s started on %s', this.frameworkName, msg.data.address);
           child.unref();
           child.disconnect();
-          process.exit(0);
+          this.exit(0);
         }
       });
 
@@ -177,7 +181,7 @@ class StartCommand extends Command {
       [ 'SIGINT', 'SIGQUIT', 'SIGTERM' ].forEach(event => {
         process.once(event, () => {
           signal = event;
-          process.exit(0);
+          this.exit(0);
         });
       });
       process.once('exit', () => {
@@ -246,7 +250,7 @@ class StartCommand extends Command {
     if (!isSuccess) {
       this.child.kill('SIGTERM');
       yield sleep(1000);
-      process.exit(1);
+      this.exit(1);
     }
   }
 }

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -72,10 +72,6 @@ class StartCommand extends Command {
     return 'Start server at prod mode';
   }
 
-  exit(code) {
-    process.exit(code);
-  }
-
   * run(context) {
     const { argv, env, cwd, execArgv } = context;
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -59,6 +59,10 @@ class Command extends BaseCommand {
 
     return context;
   }
+
+  exit(code) {
+    process.exit(code);
+  }
 }
 
 module.exports = Command;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
egg-scripts

##### Description of change
<!-- Provide a description of the change below this comment. -->
统一管控 `process.exit()`，这样对于继承的子包有更好的可操控性。