### PR TITLE
fix: use execFile instead of exec for security reason

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
-  - '9'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   matrix:
     - nodejs_version: '6'
     - nodejs_version: '8'
-    - nodejs_version: '9'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const Command = require('../command');
 const debug = require('debug')('egg-script:start');
-const { exec } = require('mz/child_process');
+const { execFile } = require('mz/child_process');
 const fs = require('mz/fs');
 const homedir = require('node-homedir');
 const mkdirp = require('mz-modules/mkdirp');
@@ -232,12 +232,15 @@ class StartCommand extends Command {
 
     if (hasError) {
       try {
-        const [ stdout ] = yield exec('tail -n 100 ' + stderr);
+        const args = [ '-n', '100', stderr ];
+        this.logger.error('tail %s', args.join(' '));
+        const [ stdout ] = yield execFile('tail', args);
         this.logger.error('Got error when startup: ');
         this.logger.error(stdout);
-      } catch (_) {
-        // nothing
+      } catch (err) {
+        this.logger.error('ignore tail error: %s', err);
       }
+
       isSuccess = ignoreStdErr;
       this.logger.error('Start got error, see %s', stderr);
       this.logger.error('Or use `--ignore-stderr` to ignore stderr at startup.');

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "bin"
   ],
   "ci": {
-    "version": "6, 8, 9"
+    "version": "6, 8, 10"
   },
   "bug": {
     "url": "https://github.com/eggjs/egg/issues"


### PR DESCRIPTION
Thanks Douglas Hall (douglas_hall) to report this security bug.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
