### PR TITLE
fix: stop process only if the title matches exactly

### DIFF
--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -12,6 +12,7 @@ const moment = require('moment');
 const sleep = require('mz-modules/sleep');
 const spawn = require('child_process').spawn;
 const utils = require('egg-utils');
+const isWin = process.platform === 'win32';
 
 class StartCommand extends Command {
   constructor(rawArgv) {
@@ -108,13 +109,14 @@ class StartCommand extends Command {
     env.HOME = HOME;
     env.NODE_ENV = 'production';
 
-    env.PATH = [
+    const platformPath = isWin ? 'Path' : 'PATH';
+    env[platformPath] = [
       // for nodeinstall
       path.join(baseDir, 'node_modules/.bin'),
       // support `.node/bin`, due to npm5 will remove `node_modules/.bin`
       path.join(baseDir, '.node/bin'),
       // adjust env for win
-      env.PATH || env.Path,
+      env[platformPath],
     ].filter(x => !!x).join(path.delimiter);
 
     // for alinode

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -108,7 +108,7 @@ class StartCommand extends Command {
     env.HOME = HOME;
     env.NODE_ENV = 'production';
 
-    // it make env morge but more robust
+    // it makes env big but more robust
     env.PATH = env.Path = [
       // for nodeinstall
       path.join(baseDir, 'node_modules/.bin'),

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -116,7 +116,7 @@ class StartCommand extends Command {
       // support `.node/bin`, due to npm5 will remove `node_modules/.bin`
       path.join(baseDir, '.node/bin'),
       // adjust env for win
-      env[platformPath],
+      env.PATH || env.Path,
     ].filter(x => !!x).join(path.delimiter);
 
     // for alinode

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -12,7 +12,6 @@ const moment = require('moment');
 const sleep = require('mz-modules/sleep');
 const spawn = require('child_process').spawn;
 const utils = require('egg-utils');
-const isWin = process.platform === 'win32';
 
 class StartCommand extends Command {
   constructor(rawArgv) {
@@ -109,8 +108,8 @@ class StartCommand extends Command {
     env.HOME = HOME;
     env.NODE_ENV = 'production';
 
-    const platformPath = isWin ? 'Path' : 'PATH';
-    env[platformPath] = [
+    // it make env morge but more robust
+    env.PATH = env.Path = [
       // for nodeinstall
       path.join(baseDir, 'node_modules/.bin'),
       // support `.node/bin`, due to npm5 will remove `node_modules/.bin`

--- a/lib/cmd/stop.js
+++ b/lib/cmd/stop.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const path = require('path');
+const util = require('util');
 const sleep = require('mz-modules/sleep');
 const Command = require('../command');
 const isWin = process.platform === 'win32';
 const osRelated = {
-  titlePrefix: isWin ? '\\"title\\":\\"' : '"title":"',
+  titleTemplate: isWin ? '\\"title\\":\\"%s\\"' : '"title":"%s"',
   appWorkerPath: isWin ? 'egg-cluster\\lib\\app_worker.js' : 'egg-cluster/lib/app_worker.js',
   agentWorkerPath: isWin ? 'egg-cluster\\lib\\agent_worker.js' : 'egg-cluster/lib/agent_worker.js',
 };
@@ -37,7 +38,7 @@ class StopCommand extends Command {
     let processList = yield this.helper.findNodeProcess(item => {
       const cmd = item.cmd;
       return argv.title ?
-        cmd.includes('start-cluster') && cmd.includes(`${osRelated.titlePrefix}${argv.title}`) :
+        cmd.includes('start-cluster') && cmd.includes(util.format(osRelated.titleTemplate, argv.title)) :
         cmd.includes('start-cluster');
     });
     let pids = processList.map(x => x.pid);
@@ -57,7 +58,7 @@ class StopCommand extends Command {
     processList = yield this.helper.findNodeProcess(item => {
       const cmd = item.cmd;
       return argv.title ?
-        (cmd.includes(osRelated.appWorkerPath) || cmd.includes(osRelated.agentWorkerPath)) && cmd.includes(`${osRelated.titlePrefix}${argv.title}`) :
+        (cmd.includes(osRelated.appWorkerPath) || cmd.includes(osRelated.agentWorkerPath)) && cmd.includes(util.format(osRelated.titleTemplate, argv.title)) :
         (cmd.includes(osRelated.appWorkerPath) || cmd.includes(osRelated.agentWorkerPath));
     });
     pids = processList.map(x => x.pid);

--- a/test/stop.test.js
+++ b/test/stop.test.js
@@ -152,6 +152,24 @@ describe('test/stop.test.js', () => {
       yield utils.cleanup(fixturePath);
     });
 
+    it('shoud stop only if the title matches exactly', function* () {
+      // Because of'exmaple'.inclues('exmap') === true，if egg-scripts <= 2.1.0 and you run `.. stop --title=exmap`，the process with 'title:example' will also be killed unexpectedly
+      yield coffee.fork(eggBin, [ 'stop', '--title=examp', fixturePath ])
+        .debug()
+        .expect('stdout', /\[egg-scripts] stopping egg application with --title=examp/)
+        .expect('stderr', /can't detect any running egg process/)
+        .expect('code', 0)
+        .end();
+
+      // stop only if the title matches exactly
+      yield coffee.fork(eggBin, [ 'stop', '--title=example', fixturePath ])
+        .debug()
+        .expect('stdout', /\[egg-scripts] stopping egg application with --title=example/)
+        .expect('stdout', /\[egg-scripts\] got master pid \[/)
+        .expect('code', 0)
+        .end();
+    });
+
     it('should stop', function* () {
       yield coffee.fork(eggBin, [ 'stop', '--title=random', fixturePath ])
         .debug()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
`egg-scripts`

##### Description of change
<!-- Provide a description of the change below this comment. -->
Because of'exmaple'.inclues('exmap') === true，if egg-scripts <= 2.1.0 and you run `.. stop --title=exmap`，the process with 'title:example' will also be killed unexpectedly，see below
1. [/lib/cmd/stop.js#L40](https://github.com/eggjs/egg-scripts/blob/1a8ad1f3baab7f9a1238d239bb5189ab26572be2/lib/cmd/stop.js#L40),
2. [/lib/cmd/stop.js#L60](https://github.com/eggjs/egg-scripts/blob/1a8ad1f3baab7f9a1238d239bb5189ab26572be2/lib/cmd/stop.js#L60)

This PR make egg-scripts stop process only if the title matches exactly.


close https://github.com/eggjs/egg/issues/3313
