### PR TITLE
test: add egg@1 and egg@2 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,19 @@ node_js:
   - '6'
   - '8'
   - '10'
+env:
+ - EGG_VERSION=1
+ - EGG_VERSION=2
+matrix:
+ exclude:
+ - node_js: '6'
+   env: EGG_VERSION=2
 install:
   - npm i npminstall && npminstall
+  - sed -i.bak '/"egg":/d' package.json
+  - npminstall -d
 script:
+  - eval "npminstall -d egg@$EGG_VERSION"
   - npm run ci
 after_script:
   - npminstall codecov && codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "coffee": "^5.1.1",
     "egg": "^2.14.1",
     "egg-bin": "^4.9.0",
-    "egg-ci": "^1.10.0",
     "eslint": "^5.10.0",
     "eslint-config-egg": "^7.1.0",
     "mm": "^2.4.1",
@@ -50,10 +49,6 @@
     "lib",
     "bin"
   ],
-  "ci": {
-    "version": "6, 8, 10",
-    "license": true
-  },
   "bug": {
     "url": "https://github.com/eggjs/egg/issues"
   },


### PR DESCRIPTION
1. For Nodejs <= 6, we don't support `async`,`await`, and this file is used
in both of the two versions. So we should make this compatable with the
two versions and not throw errors when compiling with Nodejs 6.

2. Remove 'egg-ci' (as a dependency).
3. Remove 'nodejs_version: 6' in 'appveyor.yml'.

---

- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines
