### PR TITLE
feat(lib,test,ci):drop support of Node <=6.x and use async function 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
   - '8'
   - '10'
+  - '11'
+  - '12'
 os:
   - linux
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - '8'
   - '10'
+os:
+  - windows
+  - linux
 env:
  - EGG_VERSION=1
  - EGG_VERSION=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - '8'
   - '10'
 os:
-  - windows
   - linux
 env:
  - EGG_VERSION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 env:

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -76,7 +76,7 @@ class StartCommand extends Command {
     return 'Start server at prod mode';
   }
 
-  * run(context) {
+  async run(context) {
     const { argv, env, cwd, execArgv } = context;
 
     const HOME = homedir();
@@ -91,12 +91,12 @@ class StartCommand extends Command {
 
     const isDaemon = argv.daemon;
 
-    argv.framework = yield this.getFrameworkPath({
+    argv.framework = await this.getFrameworkPath({
       framework: argv.framework,
       baseDir,
     });
 
-    this.frameworkName = yield this.getFrameworkName(argv.framework);
+    this.frameworkName = await this.getFrameworkName(argv.framework);
 
     const pkgInfo = require(path.join(baseDir, 'package.json'));
     argv.title = argv.title || `egg-server-${pkgInfo.name}`;
@@ -121,7 +121,7 @@ class StartCommand extends Command {
     // for alinode
     env.ENABLE_NODE_LOG = 'YES';
     env.NODE_LOG_DIR = env.NODE_LOG_DIR || path.join(logDir, 'alinode');
-    yield mkdirp(env.NODE_LOG_DIR);
+    await mkdirp(env.NODE_LOG_DIR);
 
     // cli argv -> process.env.EGG_SERVER_ENV -> `undefined` then egg will use `prod`
     if (argv.env) {
@@ -150,7 +150,7 @@ class StartCommand extends Command {
     // whether run in the background.
     if (isDaemon) {
       this.logger.info(`Save log file to ${logDir}`);
-      const [ stdout, stderr ] = yield [ getRotatelog(argv.stdout), getRotatelog(argv.stderr) ];
+      const [ stdout, stderr ] = await [ getRotatelog(argv.stdout), getRotatelog(argv.stderr) ];
       options.stdio = [ 'ignore', stdout, stderr, 'ipc' ];
       options.detached = true;
 
@@ -169,7 +169,7 @@ class StartCommand extends Command {
       });
 
       // check start status
-      yield this.checkStatus(argv);
+      await this.checkStatus(argv);
     } else {
       options.stdio = [ 'inherit', 'inherit', 'inherit', 'ipc' ];
       debug('Run spawn `%s %s`', command, eggArgs.join(' '));
@@ -195,11 +195,11 @@ class StartCommand extends Command {
     }
   }
 
-  * getFrameworkPath(params) {
-    return utils.getFrameworkPath(params);
+  async getFrameworkPath(params) {
+    return await utils.getFrameworkPath(params);
   }
 
-  * getFrameworkName(framework) {
+  async getFrameworkName(framework) {
     const pkgPath = path.join(framework, 'package.json');
     let name = 'egg';
     try {
@@ -209,17 +209,17 @@ class StartCommand extends Command {
     } catch (_) {
       /* istanbul next */
     }
-    return name;
+    return await name;
   }
 
-  * checkStatus({ stderr, timeout, 'ignore-stderr': ignoreStdErr }) {
+  async checkStatus({ stderr, timeout, 'ignore-stderr': ignoreStdErr }) {
     let count = 0;
     let hasError = false;
     let isSuccess = true;
     timeout = timeout / 1000;
     while (!this.isReady) {
       try {
-        const stat = yield fs.stat(stderr);
+        const stat = await fs.stat(stderr);
         if (stat && stat.size > 0) {
           hasError = true;
           break;
@@ -234,7 +234,7 @@ class StartCommand extends Command {
         break;
       }
 
-      yield sleep(1000);
+      await sleep(1000);
       this.logger.log('Wait Start: %d...', ++count);
     }
 
@@ -242,7 +242,7 @@ class StartCommand extends Command {
       try {
         const args = [ '-n', '100', stderr ];
         this.logger.error('tail %s', args.join(' '));
-        const [ stdout ] = yield execFile('tail', args);
+        const [ stdout ] = await execFile('tail', args);
         this.logger.error('Got error when startup: ');
         this.logger.error(stdout);
       } catch (err) {
@@ -256,23 +256,23 @@ class StartCommand extends Command {
 
     if (!isSuccess) {
       this.child.kill('SIGTERM');
-      yield sleep(1000);
+      await sleep(1000);
       this.exit(1);
     }
   }
 }
 
-function* getRotatelog(logfile) {
-  yield mkdirp(path.dirname(logfile));
+async function getRotatelog(logfile) {
+  await mkdirp(path.dirname(logfile));
 
-  if (yield fs.exists(logfile)) {
+  if (await fs.exists(logfile)) {
     // format style: .20150602.193100
     const timestamp = moment().format('.YYYYMMDD.HHmmss');
     // Note: rename last log to next start time, not when last log file created
-    yield fs.rename(logfile, logfile + timestamp);
+    await fs.rename(logfile, logfile + timestamp);
   }
 
-  return yield fs.open(logfile, 'a');
+  return await fs.open(logfile, 'a');
 }
 
 function stringify(obj, ignore) {

--- a/lib/cmd/start.js
+++ b/lib/cmd/start.js
@@ -150,7 +150,7 @@ class StartCommand extends Command {
     // whether run in the background.
     if (isDaemon) {
       this.logger.info(`Save log file to ${logDir}`);
-      const [ stdout, stderr ] = await [ getRotatelog(argv.stdout), getRotatelog(argv.stderr) ];
+      const [ stdout, stderr ] = await Promise.all([ getRotatelog(argv.stdout), getRotatelog(argv.stderr) ]);
       options.stdio = [ 'ignore', stdout, stderr, 'ipc' ];
       options.detached = true;
 

--- a/lib/cmd/stop.js
+++ b/lib/cmd/stop.js
@@ -29,13 +29,13 @@ class StopCommand extends Command {
     return 'Stop server';
   }
 
-  * run(context) {
+  async run(context) {
     const { argv } = context;
 
     this.logger.info(`stopping egg application ${argv.title ? `with --title=${argv.title}` : ''}`);
 
     // node /Users/tz/Workspaces/eggjs/egg-scripts/lib/start-cluster {"title":"egg-server","workers":4,"port":7001,"baseDir":"/Users/tz/Workspaces/eggjs/test/showcase","framework":"/Users/tz/Workspaces/eggjs/test/showcase/node_modules/egg"}
-    let processList = yield this.helper.findNodeProcess(item => {
+    let processList = await this.helper.findNodeProcess(item => {
       const cmd = item.cmd;
       return argv.title ?
         cmd.includes('start-cluster') && cmd.includes(util.format(osRelated.titleTemplate, argv.title)) :
@@ -47,7 +47,7 @@ class StopCommand extends Command {
       this.logger.info('got master pid %j', pids);
       this.helper.kill(pids);
       // wait for 5s to confirm whether any worker process did not kill by master
-      yield sleep('5s');
+      await sleep('5s');
     } else {
       this.logger.warn('can\'t detect any running egg process');
     }
@@ -55,7 +55,7 @@ class StopCommand extends Command {
 
     // node --debug-port=5856 /Users/tz/Workspaces/eggjs/test/showcase/node_modules/_egg-cluster@1.8.0@egg-cluster/lib/agent_worker.js {"framework":"/Users/tz/Workspaces/eggjs/test/showcase/node_modules/egg","baseDir":"/Users/tz/Workspaces/eggjs/test/showcase","port":7001,"workers":2,"plugins":null,"https":false,"key":"","cert":"","title":"egg-server","clusterPort":52406}
     // node /Users/tz/Workspaces/eggjs/test/showcase/node_modules/_egg-cluster@1.8.0@egg-cluster/lib/app_worker.js {"framework":"/Users/tz/Workspaces/eggjs/test/showcase/node_modules/egg","baseDir":"/Users/tz/Workspaces/eggjs/test/showcase","port":7001,"workers":2,"plugins":null,"https":false,"key":"","cert":"","title":"egg-server","clusterPort":52406}
-    processList = yield this.helper.findNodeProcess(item => {
+    processList = await this.helper.findNodeProcess(item => {
       const cmd = item.cmd;
       return argv.title ?
         (cmd.includes(osRelated.appWorkerPath) || cmd.includes(osRelated.agentWorkerPath)) && cmd.includes(util.format(osRelated.titleTemplate, argv.title)) :

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -4,12 +4,12 @@ const runScript = require('runscript');
 const isWin = process.platform === 'win32';
 const REGEX = isWin ? /^(.*)\s+(\d+)\s*$/ : /^\s*(\d+)\s+(.*)/;
 
-exports.findNodeProcess = function* (filterFn) {
+exports.findNodeProcess = async function (filterFn) {
   const command = isWin ?
     'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId' :
     // command, cmd are alias of args, not POSIX standard, so we use args
     'ps -eo "pid,args"';
-  const stdio = yield runScript(command, { stdio: 'pipe' });
+  const stdio = await runScript(command, { stdio: 'pipe' });
   const processList = stdio.stdout.toString().split('\n')
     .reduce((arr, line) => {
       if (!!line && !line.includes('/bin/sh') && line.includes('node')) {
@@ -24,7 +24,7 @@ exports.findNodeProcess = function* (filterFn) {
       }
       return arr;
     }, []);
-  return processList;
+  return new Promise((resolve, reject)=>{resolve(processList)});
 };
 
 exports.kill = function(pids, signal) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -4,7 +4,7 @@ const runScript = require('runscript');
 const isWin = process.platform === 'win32';
 const REGEX = isWin ? /^(.*)\s+(\d+)\s*$/ : /^\s*(\d+)\s+(.*)/;
 
-exports.findNodeProcess = async function (filterFn) {
+exports.findNodeProcess = async function(filterFn) {
   const command = isWin ?
     'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId' :
     // command, cmd are alias of args, not POSIX standard, so we use args
@@ -24,7 +24,7 @@ exports.findNodeProcess = async function (filterFn) {
       }
       return arr;
     }, []);
-  return new Promise((resolve, reject)=>{resolve(processList)});
+  return Promise.resolve(processList);
 };
 
 exports.kill = function(pids, signal) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -24,7 +24,7 @@ exports.findNodeProcess = async function(filterFn) {
       }
       return arr;
     }, []);
-  return Promise.resolve(processList);
+  return processList;
 };
 
 exports.kill = function(pids, signal) {

--- a/test/fixtures/cluster-config/app/router.js
+++ b/test/fixtures/cluster-config/app/router.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = app => {
-  app.get('/', function* () {
+  app.get('/', async function() {
     this.body = `hi, ${app.config.framework || 'egg'}`;
   });
 };

--- a/test/fixtures/custom-node-dir/app/router.js
+++ b/test/fixtures/custom-node-dir/app/router.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = app => {
-  app.get('/', function* () {
+  app.get('/', async function() {
     this.body = `hi, ${process.env.PATH}`;
   });
 };

--- a/test/fixtures/example/app/router.js
+++ b/test/fixtures/example/app/router.js
@@ -1,15 +1,15 @@
 'use strict';
 
 module.exports = app => {
-  app.get('/', function* () {
+  app.get('/',async function () {
     this.body = `hi, ${app.config.framework || 'egg'}`;
   });
 
-  app.get('/env', function* () {
+  app.get('/env',async function () {
     this.body = app.config.env + ', ' + app.config.pre;
   });
 
-  app.get('/path', function* () {
+  app.get('/path',async function () {
     this.body = process.env.PATH;
   });
 };

--- a/test/fixtures/example/app/router.js
+++ b/test/fixtures/example/app/router.js
@@ -1,15 +1,15 @@
 'use strict';
 
 module.exports = app => {
-  app.get('/',async function () {
+  app.get('/', async function() {
     this.body = `hi, ${app.config.framework || 'egg'}`;
   });
 
-  app.get('/env',async function () {
+  app.get('/env', async function() {
     this.body = app.config.env + ', ' + app.config.pre;
   });
 
-  app.get('/path',async function () {
+  app.get('/path', async function() {
     this.body = process.env.PATH;
   });
 };

--- a/test/fixtures/ipc-bin/start.js
+++ b/test/fixtures/ipc-bin/start.js
@@ -5,8 +5,8 @@ const co = require('co');
 const BaseStartCommand = require('../../../lib/cmd/start');
 
 class StartCommand extends BaseStartCommand {
-  * run(context) {
-    yield super.run(context);
+  async run(context) {
+    await super.run(context);
     const child = this.child;
     child.on('message', msg => {
       if (msg && msg.action === 'egg-ready') {
@@ -18,8 +18,9 @@ class StartCommand extends BaseStartCommand {
 
 const start = new StartCommand();
 
-co(function* () {
-  yield start.run({
+
+(async function () {
+  await start.run({
     argv: {
       framework: 'custom-framework',
       _: [ process.env.BASE_DIR ],
@@ -32,5 +33,5 @@ co(function* () {
       PATH: process.env.PATH,
     },
   });
-});
+})();
 

--- a/test/fixtures/ipc-bin/start.js
+++ b/test/fixtures/ipc-bin/start.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const co = require('co');
-
 const BaseStartCommand = require('../../../lib/cmd/start');
 
 class StartCommand extends BaseStartCommand {
@@ -19,7 +17,7 @@ class StartCommand extends BaseStartCommand {
 const start = new StartCommand();
 
 
-(async function () {
+(async function() {
   await start.run({
     argv: {
       framework: 'custom-framework',

--- a/test/fixtures/status/app.js
+++ b/test/fixtures/status/app.js
@@ -7,7 +7,7 @@ module.exports = app => {
     app.logger.error(new Error(process.env.ERROR));
   }
 
-  app.beforeStart(function* () {
-    yield sleep(process.env.WAIT_TIME);
+  app.beforeStart(async function () {
+    await sleep(process.env.WAIT_TIME);
   });
 };

--- a/test/fixtures/status/app.js
+++ b/test/fixtures/status/app.js
@@ -7,7 +7,7 @@ module.exports = app => {
     app.logger.error(new Error(process.env.ERROR));
   }
 
-  app.beforeStart(async function () {
+  app.beforeStart(async function() {
     await sleep(process.env.WAIT_TIME);
   });
 };

--- a/test/fixtures/subdir-as-basedir/base-dir/app/router.js
+++ b/test/fixtures/subdir-as-basedir/base-dir/app/router.js
@@ -1,15 +1,15 @@
 'use strict';
 
 module.exports = app => {
-  app.get('/', function* () {
+  app.get('/',async function () {
     this.body = `hi, ${app.config.framework || 'egg'}`;
   });
 
-  app.get('/env', function* () {
+  app.get('/env',async function () {
     this.body = app.config.env + ', ' + app.config.pre;
   });
 
-  app.get('/path', function* () {
+  app.get('/path',async function () {
     this.body = process.env.PATH;
   });
 };

--- a/test/fixtures/subdir-as-basedir/base-dir/app/router.js
+++ b/test/fixtures/subdir-as-basedir/base-dir/app/router.js
@@ -1,15 +1,15 @@
 'use strict';
 
 module.exports = app => {
-  app.get('/',async function () {
+  app.get('/', async function() {
     this.body = `hi, ${app.config.framework || 'egg'}`;
   });
 
-  app.get('/env',async function () {
+  app.get('/env', async function() {
     this.body = app.config.env + ', ' + app.config.pre;
   });
 
-  app.get('/path',async function () {
+  app.get('/path', async function() {
     this.body = process.env.PATH;
   });
 };

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -19,11 +19,11 @@ describe('test/start.test.js', () => {
   const logDir = path.join(homePath, 'logs');
   const waitTime = '10s';
 
-  before(function* () {
-    yield mkdirp(homePath);
+  before(async function() {
+    await mkdirp(homePath);
   });
-  after(function* () {
-    yield rimraf(homePath);
+  after(async function() {
+    await rimraf(homePath);
   });
   beforeEach(() => mm(process.env, 'MOCK_HOME_DIR', homePath));
   afterEach(mm.restore);
@@ -56,7 +56,7 @@ describe('test/start.test.js', () => {
         assert(result.data.toString() === 'hi, egg');
       });
 
-      it('should get ready', function* () {
+      it('should get ready', async function() {
         app = coffee.fork(path.join(__dirname, './fixtures/ipc-bin/start.js'), [], {
           env: {
             BASE_DIR: fixturePath,
@@ -66,7 +66,7 @@ describe('test/start.test.js', () => {
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.includes('READY!!!'));
@@ -81,22 +81,22 @@ describe('test/start.test.js', () => {
     describe('child exit with 1', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should emit spawn error', function* () {
+      it('should emit spawn error', async function() {
         const srv = require('http').createServer(() => {});
         srv.listen(7007);
 
         app = coffee.fork(eggBin, [ 'start', '--port=7007', '--workers=2', fixturePath ]);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
         assert(/Error: spawn node .+ fail, exit code: 1/.test(app.stderr));
         srv.close();
       });
@@ -105,25 +105,25 @@ describe('test/start.test.js', () => {
     describe('relative path', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', path.relative(process.cwd(), fixturePath) ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-        const result = yield httpclient.request('http://127.0.0.1:7001');
+        const result = await httpclient.request('http://127.0.0.1:7001');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -131,25 +131,25 @@ describe('test/start.test.js', () => {
     describe('without baseDir', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2' ], { cwd: fixturePath });
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-        const result = yield httpclient.request('http://127.0.0.1:7001');
+        const result = await httpclient.request('http://127.0.0.1:7001');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -157,25 +157,25 @@ describe('test/start.test.js', () => {
     describe('--framework', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--framework=yadan', '--workers=2', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/yadan started on http:\/\/127\.0\.0\.1:7001/));
-        const result = yield httpclient.request('http://127.0.0.1:7001');
+        const result = await httpclient.request('http://127.0.0.1:7001');
         assert(result.data.toString() === 'hi, yadan');
       });
     });
@@ -183,21 +183,21 @@ describe('test/start.test.js', () => {
     describe('--title', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', '--title=egg-test', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.includes('--title=egg-test'));
@@ -205,7 +205,7 @@ describe('test/start.test.js', () => {
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
         assert(app.stdout.includes('app_worker#2:'));
         assert(!app.stdout.includes('app_worker#3:'));
-        const result = yield httpclient.request('http://127.0.0.1:7001');
+        const result = await httpclient.request('http://127.0.0.1:7001');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -213,25 +213,25 @@ describe('test/start.test.js', () => {
     describe('--port', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--port=7002', '--workers=2', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7002/));
-        const result = yield httpclient.request('http://127.0.0.1:7002');
+        const result = await httpclient.request('http://127.0.0.1:7002');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -239,25 +239,25 @@ describe('test/start.test.js', () => {
     describe('process.env.PORT', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ], { env: Object.assign({}, process.env, { PORT: 7002 }) });
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7002/));
-        const result = yield httpclient.request('http://127.0.0.1:7002');
+        const result = await httpclient.request('http://127.0.0.1:7002');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -265,25 +265,25 @@ describe('test/start.test.js', () => {
     describe('--env', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', '--env=pre', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-        const result = yield httpclient.request('http://127.0.0.1:7001/env');
+        const result = await httpclient.request('http://127.0.0.1:7001/env');
         assert(result.data.toString() === 'pre, true');
       });
     });
@@ -291,30 +291,30 @@ describe('test/start.test.js', () => {
     describe('custom env', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
+      before(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         mm(process.env, 'CUSTOM_ENV', 'pre');
         app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.includes('## EGG_SERVER_ENV is not pass'));
         assert(app.stdout.includes('## CUSTOM_ENV: pre'));
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-        let result = yield httpclient.request('http://127.0.0.1:7001/env');
+        let result = await httpclient.request('http://127.0.0.1:7001/env');
         assert(result.data.toString() === 'pre, true');
-        result = yield httpclient.request('http://127.0.0.1:7001/path');
+        result = await httpclient.request('http://127.0.0.1:7001/path');
         const appBinPath = path.join(fixturePath, 'node_modules/.bin');
         assert(result.data.toString().startsWith(`${appBinPath}${path.delimiter}`));
       });
@@ -323,38 +323,38 @@ describe('test/start.test.js', () => {
     describe('--stdout --stderr', () => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
-        yield rimraf(logDir);
-        yield rimraf(path.join(fixturePath, 'start-fail'));
-        yield mkdirp(logDir);
+      before(async function() {
+        await utils.cleanup(fixturePath);
+        await rimraf(logDir);
+        await rimraf(path.join(fixturePath, 'start-fail'));
+        await mkdirp(logDir);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
-        yield rimraf(path.join(fixturePath, 'stdout.log'));
-        yield rimraf(path.join(fixturePath, 'stderr.log'));
-        yield rimraf(path.join(fixturePath, 'start-fail'));
+        await utils.cleanup(fixturePath);
+        await rimraf(path.join(fixturePath, 'stdout.log'));
+        await rimraf(path.join(fixturePath, 'stderr.log'));
+        await rimraf(path.join(fixturePath, 'start-fail'));
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         const stdout = path.join(fixturePath, 'stdout.log');
         const stderr = path.join(fixturePath, 'stderr.log');
         app = coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdout}`, `--stderr=${stderr}`, fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
-        let content = yield fs.readFile(stdout, 'utf-8');
+        let content = await fs.readFile(stdout, 'utf-8');
         assert(content.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
 
-        content = yield fs.readFile(stderr, 'utf-8');
+        content = await fs.readFile(stderr, 'utf-8');
         assert(content === '');
       });
 
-      it('should start with insecurity --stderr argument', function* () {
+      it('should start with insecurity --stderr argument', async function() {
         const cwd = path.join(__dirname, 'fixtures/status');
         mm(process.env, 'ERROR', 'error message');
 
@@ -368,13 +368,13 @@ describe('test/start.test.js', () => {
         ]);
         // app.debug();
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
-        const content = yield fs.readFile(stdout, 'utf-8');
+        const content = await fs.readFile(stdout, 'utf-8');
         assert(!content.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-        let exists = yield fs.exists(stderr);
+        let exists = await fs.exists(stderr);
         assert(!exists);
-        exists = yield fs.exists(malicious);
+        exists = await fs.exists(malicious);
         assert(!exists);
       });
     });
@@ -382,59 +382,59 @@ describe('test/start.test.js', () => {
     describe('--node', () => {
       let app;
 
-      beforeEach(function* () {
-        yield utils.cleanup(fixturePath);
+      beforeEach(async function() {
+        await utils.cleanup(fixturePath);
       });
 
-      beforeEach(function* () {
+      beforeEach(async function() {
         app && app.proc && app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
       describe('daemon', () => {
-        it('should start', function* () {
+        it('should start', async function() {
           app = coffee.fork(eggBin, [ 'start', '--daemon', '--framework=yadan', '--workers=2', `--node=${process.execPath}`, fixturePath ]);
           // app.debug();
           app.expect('code', 0);
 
-          yield sleep(waitTime);
+          await sleep(waitTime);
 
           assert(app.stderr === '');
           assert(app.stdout.match(/yadan started on http:\/\/127\.0\.0\.1:7001/));
-          const result = yield httpclient.request('http://127.0.0.1:7001');
+          const result = await httpclient.request('http://127.0.0.1:7001');
           assert(result.data.toString() === 'hi, yadan');
         });
 
-        it('should error if node path invalid', function* () {
+        it('should error if node path invalid', async function() {
           app = coffee.fork(eggBin, [ 'start', '--daemon', '--framework=yadan', '--workers=2', '--node=invalid', fixturePath ]);
           // app.debug();
           app.expect('code', 1);
 
-          yield sleep(3000);
+          await sleep(3000);
           assert(app.stderr.includes('spawn invalid ENOENT'));
         });
       });
 
       describe('not daemon', () => {
-        it('should start', function* () {
+        it('should start', async function() {
           app = coffee.fork(eggBin, [ 'start', '--framework=yadan', '--workers=2', `--node=${process.execPath}`, fixturePath ]);
           // app.debug();
           app.expect('code', 0);
 
-          yield sleep(waitTime);
+          await sleep(waitTime);
 
           assert(app.stderr === '');
           assert(app.stdout.match(/yadan started on http:\/\/127\.0\.0\.1:7001/));
-          const result = yield httpclient.request('http://127.0.0.1:7001');
+          const result = await httpclient.request('http://127.0.0.1:7001');
           assert(result.data.toString() === 'hi, yadan');
         });
 
-        it('should error if node path invalid', function* () {
+        it('should error if node path invalid', async function() {
           app = coffee.fork(eggBin, [ 'start', '--framework=yadan', '--workers=2', '--node=invalid', fixturePath ]);
           // app.debug();
           app.expect('code', 1);
 
-          yield sleep(3000);
+          await sleep(3000);
           assert(app.stderr.includes('spawn invalid ENOENT'));
         });
       });
@@ -444,27 +444,27 @@ describe('test/start.test.js', () => {
       let app;
       let fixturePath;
 
-      before(function* () {
+      before(async function() {
         fixturePath = path.join(__dirname, 'fixtures/cluster-config');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:8000/));
         assert(!app.stdout.includes('app_worker#3:'));
-        const result = yield httpclient.request('http://127.0.0.1:8000');
+        const result = await httpclient.request('http://127.0.0.1:8000');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -474,25 +474,25 @@ describe('test/start.test.js', () => {
       const rootDir = path.join(__dirname, '..');
       const subDir = path.join(__dirname, 'fixtures/subdir-as-basedir/base-dir');
 
-      before(function* () {
-        yield utils.cleanup(rootDir);
+      before(async function() {
+        await utils.cleanup(rootDir);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(rootDir);
+        await utils.cleanup(rootDir);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', subDir ], { cwd: rootDir });
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
-        const result = yield httpclient.request('http://127.0.0.1:7001');
+        const result = await httpclient.request('http://127.0.0.1:7001');
         assert(result.data.toString() === 'hi, egg');
       });
     });
@@ -501,17 +501,17 @@ describe('test/start.test.js', () => {
       let app;
       let fixturePath;
 
-      before(function* () {
+      before(async function() {
         fixturePath = path.join(__dirname, 'fixtures/custom-node-dir');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      after(function* () {
+      after(async function() {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start', async function() {
         const expectPATH = [
           path.join(fixturePath, 'node_modules/.bin'),
           path.join(fixturePath, '.node/bin'),
@@ -520,12 +520,12 @@ describe('test/start.test.js', () => {
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7002/));
         assert(!app.stdout.includes('app_worker#3:'));
-        const result = yield httpclient.request('http://127.0.0.1:7002');
+        const result = await httpclient.request('http://127.0.0.1:7002');
         assert(result.data.toString().startsWith(`hi, ${expectPATH}`));
       });
     });
@@ -533,23 +533,23 @@ describe('test/start.test.js', () => {
 
   describe('start with daemon', () => {
     let cwd;
-    beforeEach(function* () {
-      if (cwd) yield utils.cleanup(cwd);
-      yield rimraf(logDir);
-      yield mkdirp(logDir);
-      yield fs.writeFile(path.join(logDir, 'master-stdout.log'), 'just for test');
-      yield fs.writeFile(path.join(logDir, 'master-stderr.log'), 'just for test');
+    beforeEach(async function() {
+      if (cwd) await utils.cleanup(cwd);
+      await rimraf(logDir);
+      await mkdirp(logDir);
+      await fs.writeFile(path.join(logDir, 'master-stdout.log'), 'just for test');
+      await fs.writeFile(path.join(logDir, 'master-stderr.log'), 'just for test');
     });
-    afterEach(function* () {
-      yield coffee.fork(eggBin, [ 'stop', cwd ])
+    afterEach(async function() {
+      await coffee.fork(eggBin, [ 'stop', cwd ])
       // .debug()
         .end();
-      yield utils.cleanup(cwd);
+      await utils.cleanup(cwd);
     });
 
-    it('should start custom-framework', function* () {
+    it('should start custom-framework', async function() {
       cwd = fixturePath;
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', '--port=7002', cwd ])
+      await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', '--port=7002', cwd ])
       // .debug()
         .expect('stdout', /Starting custom-framework application/)
         .expect('stdout', /custom-framework started on http:\/\/127\.0\.0\.1:7002/)
@@ -557,23 +557,23 @@ describe('test/start.test.js', () => {
         .end();
 
       // master log
-      const stdout = yield fs.readFile(path.join(logDir, 'master-stdout.log'), 'utf-8');
-      const stderr = yield fs.readFile(path.join(logDir, 'master-stderr.log'), 'utf-8');
+      const stdout = await fs.readFile(path.join(logDir, 'master-stdout.log'), 'utf-8');
+      const stderr = await fs.readFile(path.join(logDir, 'master-stderr.log'), 'utf-8');
       assert(stderr === '');
       assert(stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7002/));
 
       // should rotate log
-      const fileList = yield fs.readdir(logDir);
+      const fileList = await fs.readdir(logDir);
       assert(fileList.some(name => name.match(/master-stdout\.log\.\d+\.\d+/)));
       assert(fileList.some(name => name.match(/master-stderr\.log\.\d+\.\d+/)));
 
-      const result = yield httpclient.request('http://127.0.0.1:7002');
+      const result = await httpclient.request('http://127.0.0.1:7002');
       assert(result.data.toString() === 'hi, egg');
     });
 
-    it('should start default egg', function* () {
+    it('should start default egg', async function() {
       cwd = path.join(__dirname, 'fixtures/egg-app');
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', cwd ])
+      await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', cwd ])
       // .debug()
         .expect('stdout', /Starting egg application/)
         .expect('stdout', /egg started on http:\/\/127\.0\.0\.1:7001/)
@@ -585,16 +585,16 @@ describe('test/start.test.js', () => {
   describe('check status', () => {
     const cwd = path.join(__dirname, 'fixtures/status');
 
-    after(function* () {
-      yield coffee.fork(eggBin, [ 'stop', cwd ])
+    after(async function() {
+      await coffee.fork(eggBin, [ 'stop', cwd ])
       // .debug()
         .end();
-      yield utils.cleanup(cwd);
+      await utils.cleanup(cwd);
     });
 
-    it('should status check success, exit with 0', function* () {
+    it('should status check success, exit with 0', async function() {
       mm(process.env, 'WAIT_TIME', 5000);
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1' ], { cwd })
+      await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1' ], { cwd })
       // .debug()
         .expect('stdout', /Wait Start: 5.../)
         .expect('stdout', /custom-framework started/)
@@ -602,7 +602,7 @@ describe('test/start.test.js', () => {
         .end();
     });
 
-    it('should status check fail `--ignore-stderr`, exit with 0', function* () {
+    it('should status check fail `--ignore-stderr`, exit with 0', async function() {
       mm(process.env, 'WAIT_TIME', 5000);
       mm(process.env, 'ERROR', 'error message');
 
@@ -613,12 +613,12 @@ describe('test/start.test.js', () => {
       // app.debug();
       // TODO: find a windows replacement for tail command
       if (!isWin) app.expect('stderr', /nodejs.Error: error message/);
-      yield app.expect('stderr', new RegExp(`Start got error, see ${stderr}`))
+      await app.expect('stderr', new RegExp(`Start got error, see ${stderr}`))
         .expect('code', 0)
         .end();
     });
 
-    it('should status check fail, exit with 1', function* () {
+    it('should status check fail, exit with 1', async function() {
       mm(process.env, 'WAIT_TIME', 5000);
       mm(process.env, 'ERROR', 'error message');
 
@@ -629,16 +629,16 @@ describe('test/start.test.js', () => {
       // app.debug();
       // TODO: find a windows replacement for tail command
       if (!isWin) app.expect('stderr', /nodejs.Error: error message/);
-      yield app.expect('stderr', new RegExp(`Start got error, see ${stderr}`))
+      await app.expect('stderr', new RegExp(`Start got error, see ${stderr}`))
         .expect('stderr', /Got error when startup/)
         .expect('code', 1)
         .end();
     });
 
-    it('should status check timeout and exit with code 1', function* () {
+    it('should status check timeout and exit with code 1', async function() {
       mm(process.env, 'WAIT_TIME', 10000);
 
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1', '--timeout=5000' ], { cwd })
+      await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=1', '--timeout=5000' ], { cwd })
       // .debug()
         .expect('stdout', /Wait Start: 1.../)
         .expect('stderr', /Start failed, 5s timeout/)

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -29,17 +29,17 @@ describe('test/start.test.js', () => {
   afterEach(mm.restore);
 
   describe('start without daemon', () => {
-    describe('full path',() => {
+    describe('full path', () => {
       let app;
 
-      before(async ()=>{await utils.cleanup(fixturePath)});
+      before(async () => { await utils.cleanup(fixturePath); });
 
-      afterEach(async function () {
+      afterEach(async function() {
         app.proc.kill('SIGTERM');
         await utils.cleanup(fixturePath);
       });
 
-      it('should start',async function () {
+      it('should start', async function() {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ]);
         // app.debug();
         app.expect('code', 0);

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -342,7 +342,7 @@ describe('test/start.test.js', () => {
         const stdoutFile = path.join(fixturePath, 'stdout.log');
         const stderrFile = path.join(fixturePath, 'stderr.log');
         const { stdout, stderr, code } = await coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdoutFile}`, `--stderr=${stderrFile}`, fixturePath ]).end();
-        assert(code===0);
+        assert(code === 0);
         await sleep(waitTime);
 
         let content = await fs.readFile(stdout, 'utf-8');

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -29,24 +29,22 @@ describe('test/start.test.js', () => {
   afterEach(mm.restore);
 
   describe('start without daemon', () => {
-    describe('full path', () => {
+    describe('full path',() => {
       let app;
 
-      before(function* () {
-        yield utils.cleanup(fixturePath);
-      });
+      before(async ()=>{await utils.cleanup(fixturePath)});
 
-      afterEach(function* () {
+      afterEach(async function () {
         app.proc.kill('SIGTERM');
-        yield utils.cleanup(fixturePath);
+        await utils.cleanup(fixturePath);
       });
 
-      it('should start', function* () {
+      it('should start',async function () {
         app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ]);
         // app.debug();
         app.expect('code', 0);
 
-        yield sleep(waitTime);
+        await sleep(waitTime);
 
         assert(app.stderr === '');
         assert(app.stdout.includes('--title=egg-server-example'));
@@ -54,7 +52,7 @@ describe('test/start.test.js', () => {
         assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
         assert(app.stdout.includes('app_worker#2:'));
         assert(!app.stdout.includes('app_worker#3:'));
-        const result = yield httpclient.request('http://127.0.0.1:7001');
+        const result = await httpclient.request('http://127.0.0.1:7001');
         assert(result.data.toString() === 'hi, egg');
       });
 

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -580,6 +580,30 @@ describe('test/start.test.js', () => {
     });
   });
 
+  describe('start with windowsHide', () => {
+    let cwd;
+    beforeEach(async function() {
+      if (cwd) await utils.cleanup(cwd);
+      await rimraf(logDir);
+      await mkdirp(logDir);
+      await fs.writeFile(path.join(logDir, 'master-stdout.log'), 'just for test');
+      await fs.writeFile(path.join(logDir, 'master-stderr.log'), 'just for test');
+    });
+    afterEach(async function() {
+      await coffee.fork(eggBin, [ 'stop', cwd ])
+      // .debug()
+        .end();
+      await utils.cleanup(cwd);
+    });
+
+    it('should start with --windowsHide', async function() {
+      cwd = fixturePath;
+      let app= coffee.fork(eggBin, [ 'start', '--daemon', '--windowsHide', '--workers=2', '--port=7002', cwd ]);
+      app.expect('code', 0);
+      assert(app.stdout.includes('"windowsHide":true'));
+    });
+  });
+
   describe('check status', () => {
     const cwd = path.join(__dirname, 'fixtures/status');
 

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -342,6 +342,7 @@ describe('test/start.test.js', () => {
         const stdoutFile = path.join(fixturePath, 'stdout.log');
         const stderrFile = path.join(fixturePath, 'stderr.log');
         const { stdout, stderr, code } = await coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdoutFile}`, `--stderr=${stderrFile}`, fixturePath ]).end();
+        assert(code===0);
         await sleep(waitTime);
 
         let content = await fs.readFile(stdout, 'utf-8');

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -598,7 +598,7 @@ describe('test/start.test.js', () => {
 
     it('should start with --windowsHide', async function() {
       cwd = fixturePath;
-      let app= coffee.fork(eggBin, [ 'start', '--daemon', '--windowsHide', '--workers=2', '--port=7002', cwd ]);
+      const app = coffee.fork(eggBin, [ 'start', '--daemon', '--windowsHide', '--workers=2', '--port=7002', cwd ]);
       app.expect('code', 0);
       assert(app.stdout.includes('"windowsHide":true'));
     });

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -339,12 +339,9 @@ describe('test/start.test.js', () => {
       });
 
       it('should start', async function() {
-        const stdout = path.join(fixturePath, 'stdout.log');
-        const stderr = path.join(fixturePath, 'stderr.log');
-        app = coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdout}`, `--stderr=${stderr}`, fixturePath ]);
-        // app.debug();
-        app.expect('code', 0);
-
+        const stdoutFile = path.join(fixturePath, 'stdout.log');
+        const stderrFile = path.join(fixturePath, 'stderr.log');
+        const { stdout, stderr, code } = await coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdoutFile}`, `--stderr=${stderrFile}`, fixturePath ]).end();
         await sleep(waitTime);
 
         let content = await fs.readFile(stdout, 'utf-8');

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -600,6 +600,7 @@ describe('test/start.test.js', () => {
       cwd = fixturePath;
       const app = coffee.fork(eggBin, [ 'start', '--daemon', '--windowsHide', '--workers=2', '--port=7002', cwd ]);
       app.expect('code', 0);
+      await sleep(waitTime);
       assert(app.stdout.includes('"windowsHide":true'));
     });
   });

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -339,9 +339,9 @@ describe('test/start.test.js', () => {
       });
 
       it('should start', async function() {
-        const stdoutFile = path.join(fixturePath, 'stdout.log');
-        const stderrFile = path.join(fixturePath, 'stderr.log');
-        const { stdout, stderr, code } = await coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdoutFile}`, `--stderr=${stderrFile}`, fixturePath ]).end();
+        const stdout = path.join(fixturePath, 'stdout.log');
+        const stderr = path.join(fixturePath, 'stderr.log');
+        const { code } = await coffee.fork(eggBin, [ 'start', '--workers=1', '--daemon', `--stdout=${stdout}`, `--stderr=${stderr}`, fixturePath ]).end();
         assert(code === 0);
         await sleep(waitTime);
 

--- a/test/stop.test.js
+++ b/test/stop.test.js
@@ -19,10 +19,10 @@ describe('test/stop.test.js', () => {
   const logDir = path.join(homePath, 'logs');
   const waitTime = '10s';
 
-  before(async function () {
+  before(async function() {
     await mkdirp(homePath);
   });
-  after(async function () {
+  after(async function() {
     await rimraf(homePath);
   });
   beforeEach(() => mm(process.env, 'MOCK_HOME_DIR', homePath));
@@ -32,7 +32,7 @@ describe('test/stop.test.js', () => {
     let app;
     let killer;
 
-    beforeEach(async function () {
+    beforeEach(async function() {
       await utils.cleanup(fixturePath);
       app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ]);
       // app.debug();
@@ -45,12 +45,12 @@ describe('test/stop.test.js', () => {
       assert(result.data.toString() === 'hi, egg');
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       app.proc.kill('SIGTERM');
       await utils.cleanup(fixturePath);
     });
 
-    it('should stop',async function () {
+    it('should stop', async function() {
       killer = coffee.fork(eggBin, [ 'stop', fixturePath ]);
       killer.debug();
       killer.expect('code', 0);
@@ -75,7 +75,7 @@ describe('test/stop.test.js', () => {
   });
 
   describe('stop with daemon', () => {
-    beforeEach(async function () {
+    beforeEach(async function() {
       await utils.cleanup(fixturePath);
       await rimraf(logDir);
       await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', fixturePath ])
@@ -86,11 +86,11 @@ describe('test/stop.test.js', () => {
       const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
     });
-    afterEach(async function () {
+    afterEach(async function() {
       await utils.cleanup(fixturePath);
     });
 
-    it('should stop',async function () {
+    it('should stop', async function() {
       await coffee.fork(eggBin, [ 'stop', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application/)
@@ -119,7 +119,7 @@ describe('test/stop.test.js', () => {
   });
 
   describe('stop with not exist', () => {
-    it('should work',async function () {
+    it('should work', async function() {
       await utils.cleanup(fixturePath);
       await coffee.fork(eggBin, [ 'stop', fixturePath ])
         .debug()
@@ -134,7 +134,7 @@ describe('test/stop.test.js', () => {
     let app;
     let killer;
 
-    beforeEach(async function () {
+    beforeEach(async function() {
       await utils.cleanup(fixturePath);
       app = coffee.fork(eggBin, [ 'start', '--workers=2', '--title=example', fixturePath ]);
       // app.debug();
@@ -147,12 +147,12 @@ describe('test/stop.test.js', () => {
       assert(result.data.toString() === 'hi, egg');
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       app.proc.kill('SIGTERM');
       await utils.cleanup(fixturePath);
     });
 
-    it('shoud stop only if the title matches exactly',async function () {
+    it('shoud stop only if the title matches exactly', async function() {
       // Because of'exmaple'.inclues('exmap') === true，if egg-scripts <= 2.1.0 and you run `.. stop --title=exmap`，the process with 'title:example' will also be killed unexpectedly
       await coffee.fork(eggBin, [ 'stop', '--title=examp', fixturePath ])
         .debug()
@@ -170,7 +170,7 @@ describe('test/stop.test.js', () => {
         .end();
     });
 
-    it('should stop',async function () {
+    it('should stop', async function() {
       await coffee.fork(eggBin, [ 'stop', '--title=random', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application with --title=random/)
@@ -206,7 +206,7 @@ describe('test/stop.test.js', () => {
     let app2;
     let killer;
 
-    beforeEach(async function () {
+    beforeEach(async function() {
       await utils.cleanup(fixturePath);
       app = coffee.fork(eggBin, [ 'start', '--workers=2', '--title=example', fixturePath ]);
       // app.debug();
@@ -228,13 +228,13 @@ describe('test/stop.test.js', () => {
       assert(result2.data.toString() === 'hi, egg');
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       app.proc.kill('SIGTERM');
       app2.proc.kill('SIGTERM');
       await utils.cleanup(fixturePath);
     });
 
-    it('should stop',async function () {
+    it('should stop', async function() {
       killer = coffee.fork(eggBin, [ 'stop' ], { cwd: fixturePath });
       killer.debug();
       killer.expect('code', 0);
@@ -270,7 +270,7 @@ describe('test/stop.test.js', () => {
   describe('stop with symlink', () => {
     const baseDir = path.join(__dirname, 'fixtures/tmp');
 
-    beforeEach(async function () {
+    beforeEach(async function() {
       // if we can't create a symlink, skip the test
       try {
         await fs.symlink(fixturePath, baseDir, 'dir');
@@ -295,12 +295,12 @@ describe('test/stop.test.js', () => {
       const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
     });
-    afterEach(async function () {
+    afterEach(async function() {
       await utils.cleanup(fixturePath);
       await rimraf(baseDir);
     });
 
-    it('should stop',async function () {
+    it('should stop', async function() {
       await rimraf(baseDir);
       await fs.symlink(path.join(__dirname, 'fixtures/status'), baseDir);
 

--- a/test/stop.test.js
+++ b/test/stop.test.js
@@ -19,11 +19,11 @@ describe('test/stop.test.js', () => {
   const logDir = path.join(homePath, 'logs');
   const waitTime = '10s';
 
-  before(function* () {
-    yield mkdirp(homePath);
+  before(async function () {
+    await mkdirp(homePath);
   });
-  after(function* () {
-    yield rimraf(homePath);
+  after(async function () {
+    await rimraf(homePath);
   });
   beforeEach(() => mm(process.env, 'MOCK_HOME_DIR', homePath));
   afterEach(() => mm.restore);
@@ -32,31 +32,31 @@ describe('test/stop.test.js', () => {
     let app;
     let killer;
 
-    beforeEach(function* () {
-      yield utils.cleanup(fixturePath);
+    beforeEach(async function () {
+      await utils.cleanup(fixturePath);
       app = coffee.fork(eggBin, [ 'start', '--workers=2', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001');
+      const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
     });
 
-    afterEach(function* () {
+    afterEach(async function () {
       app.proc.kill('SIGTERM');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
     });
 
-    it('should stop', function* () {
+    it('should stop',async function () {
       killer = coffee.fork(eggBin, [ 'stop', fixturePath ]);
       killer.debug();
       killer.expect('code', 0);
 
       // yield killer.end();
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       // make sure is kill not auto exist
       assert(!app.stdout.includes('exist by env'));
@@ -75,33 +75,33 @@ describe('test/stop.test.js', () => {
   });
 
   describe('stop with daemon', () => {
-    beforeEach(function* () {
-      yield utils.cleanup(fixturePath);
-      yield rimraf(logDir);
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', fixturePath ])
+    beforeEach(async function () {
+      await utils.cleanup(fixturePath);
+      await rimraf(logDir);
+      await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2', fixturePath ])
         .debug()
         .expect('code', 0)
         .end();
 
-      const result = yield httpclient.request('http://127.0.0.1:7001');
+      const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
     });
-    afterEach(function* () {
-      yield utils.cleanup(fixturePath);
+    afterEach(async function () {
+      await utils.cleanup(fixturePath);
     });
 
-    it('should stop', function* () {
-      yield coffee.fork(eggBin, [ 'stop', fixturePath ])
+    it('should stop',async function () {
+      await coffee.fork(eggBin, [ 'stop', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application/)
         .expect('stdout', /got master pid \["\d+\"\]/i)
         .expect('code', 0)
         .end();
 
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       // master log
-      const stdout = yield fs.readFile(path.join(logDir, 'master-stdout.log'), 'utf-8');
+      const stdout = await fs.readFile(path.join(logDir, 'master-stdout.log'), 'utf-8');
 
       // no way to handle the SIGTERM signal in windows ?
       if (!isWin) {
@@ -110,7 +110,7 @@ describe('test/stop.test.js', () => {
         assert(stdout.includes('[app_worker] exit with code:0'));
       }
 
-      yield coffee.fork(eggBin, [ 'stop', fixturePath ])
+      await coffee.fork(eggBin, [ 'stop', fixturePath ])
         .debug()
         .expect('stderr', /can't detect any running egg process/)
         .expect('code', 0)
@@ -119,9 +119,9 @@ describe('test/stop.test.js', () => {
   });
 
   describe('stop with not exist', () => {
-    it('should work', function* () {
-      yield utils.cleanup(fixturePath);
-      yield coffee.fork(eggBin, [ 'stop', fixturePath ])
+    it('should work',async function () {
+      await utils.cleanup(fixturePath);
+      await coffee.fork(eggBin, [ 'stop', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application/)
         .expect('stderr', /can't detect any running egg process/)
@@ -134,27 +134,27 @@ describe('test/stop.test.js', () => {
     let app;
     let killer;
 
-    beforeEach(function* () {
-      yield utils.cleanup(fixturePath);
+    beforeEach(async function () {
+      await utils.cleanup(fixturePath);
       app = coffee.fork(eggBin, [ 'start', '--workers=2', '--title=example', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001');
+      const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
     });
 
-    afterEach(function* () {
+    afterEach(async function () {
       app.proc.kill('SIGTERM');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
     });
 
-    it('shoud stop only if the title matches exactly', function* () {
+    it('shoud stop only if the title matches exactly',async function () {
       // Because of'exmaple'.inclues('exmap') === true，if egg-scripts <= 2.1.0 and you run `.. stop --title=exmap`，the process with 'title:example' will also be killed unexpectedly
-      yield coffee.fork(eggBin, [ 'stop', '--title=examp', fixturePath ])
+      await coffee.fork(eggBin, [ 'stop', '--title=examp', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application with --title=examp/)
         .expect('stderr', /can't detect any running egg process/)
@@ -162,7 +162,7 @@ describe('test/stop.test.js', () => {
         .end();
 
       // stop only if the title matches exactly
-      yield coffee.fork(eggBin, [ 'stop', '--title=example', fixturePath ])
+      await coffee.fork(eggBin, [ 'stop', '--title=example', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application with --title=example/)
         .expect('stdout', /\[egg-scripts\] got master pid \[/)
@@ -170,8 +170,8 @@ describe('test/stop.test.js', () => {
         .end();
     });
 
-    it('should stop', function* () {
-      yield coffee.fork(eggBin, [ 'stop', '--title=random', fixturePath ])
+    it('should stop',async function () {
+      await coffee.fork(eggBin, [ 'stop', '--title=random', fixturePath ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application with --title=random/)
         .expect('stderr', /can't detect any running egg process/)
@@ -183,7 +183,7 @@ describe('test/stop.test.js', () => {
       killer.expect('code', 0);
 
       // yield killer.end();
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       // make sure is kill not auto exist
       assert(!app.stdout.includes('exist by env'));
@@ -206,8 +206,8 @@ describe('test/stop.test.js', () => {
     let app2;
     let killer;
 
-    beforeEach(function* () {
-      yield utils.cleanup(fixturePath);
+    beforeEach(async function () {
+      await utils.cleanup(fixturePath);
       app = coffee.fork(eggBin, [ 'start', '--workers=2', '--title=example', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
@@ -215,32 +215,32 @@ describe('test/stop.test.js', () => {
       app2 = coffee.fork(eggBin, [ 'start', '--workers=2', '--title=test', '--port=7002', fixturePath ]);
       app2.expect('code', 0);
 
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001');
+      const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
 
       assert(app2.stderr === '');
       assert(app2.stdout.match(/custom-framework started on http:\/\/127\.0\.0\.1:7002/));
-      const result2 = yield httpclient.request('http://127.0.0.1:7002');
+      const result2 = await httpclient.request('http://127.0.0.1:7002');
       assert(result2.data.toString() === 'hi, egg');
     });
 
-    afterEach(function* () {
+    afterEach(async function () {
       app.proc.kill('SIGTERM');
       app2.proc.kill('SIGTERM');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
     });
 
-    it('should stop', function* () {
+    it('should stop',async function () {
       killer = coffee.fork(eggBin, [ 'stop' ], { cwd: fixturePath });
       killer.debug();
       killer.expect('code', 0);
 
       // yield killer.end();
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       // make sure is kill not auto exist
       assert(!app.stdout.includes('exist by env'));
@@ -270,10 +270,10 @@ describe('test/stop.test.js', () => {
   describe('stop with symlink', () => {
     const baseDir = path.join(__dirname, 'fixtures/tmp');
 
-    beforeEach(function* () {
+    beforeEach(async function () {
       // if we can't create a symlink, skip the test
       try {
-        yield fs.symlink(fixturePath, baseDir, 'dir');
+        await fs.symlink(fixturePath, baseDir, 'dir');
       } catch (err) {
         // may get Error: EPERM: operation not permitted on windows
         console.log(`test skiped, can't create symlink: ${err}`);
@@ -283,28 +283,28 @@ describe('test/stop.test.js', () => {
       // *unix get the real path of symlink, but windows wouldn't
       const appPathInRegexp = isWin ? baseDir.replace(/\\/g, '\\\\') : fixturePath;
 
-      yield utils.cleanup(fixturePath);
-      yield rimraf(logDir);
-      yield coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2' ], { cwd: baseDir })
+      await utils.cleanup(fixturePath);
+      await rimraf(logDir);
+      await coffee.fork(eggBin, [ 'start', '--daemon', '--workers=2' ], { cwd: baseDir })
         .debug()
         .expect('stdout', new RegExp(`Starting custom-framework application at ${appPathInRegexp}`))
         .expect('code', 0)
         .end();
 
-      yield rimraf(baseDir);
-      const result = yield httpclient.request('http://127.0.0.1:7001');
+      await rimraf(baseDir);
+      const result = await httpclient.request('http://127.0.0.1:7001');
       assert(result.data.toString() === 'hi, egg');
     });
-    afterEach(function* () {
-      yield utils.cleanup(fixturePath);
-      yield rimraf(baseDir);
+    afterEach(async function () {
+      await utils.cleanup(fixturePath);
+      await rimraf(baseDir);
     });
 
-    it('should stop', function* () {
-      yield rimraf(baseDir);
-      yield fs.symlink(path.join(__dirname, 'fixtures/status'), baseDir);
+    it('should stop',async function () {
+      await rimraf(baseDir);
+      await fs.symlink(path.join(__dirname, 'fixtures/status'), baseDir);
 
-      yield coffee.fork(eggBin, [ 'stop', baseDir ])
+      await coffee.fork(eggBin, [ 'stop', baseDir ])
         .debug()
         .expect('stdout', /\[egg-scripts] stopping egg application/)
         .expect('stdout', /got master pid \["\d+\"\]/i)

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -26,19 +26,19 @@ describe('test/ts.test.js', () => {
 
   describe('should display correct stack traces', () => {
     let app;
-    beforeEach(async function () {
+    beforeEach(async function() {
       fixturePath = path.join(__dirname, 'fixtures/ts');
       await utils.cleanup(fixturePath);
       const result = cp.spawnSync('npm', [ 'run', isWin ? 'windows-build' : 'build' ], { cwd: fixturePath, shell: isWin });
       assert(!result.stderr.toString());
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       app && app.proc.kill('SIGTERM');
       await utils.cleanup(fixturePath);
     });
 
-    it('--ts',async function () {
+    it('--ts', async function() {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', '--ts', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
@@ -52,7 +52,7 @@ describe('test/ts.test.js', () => {
       assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
 
-    it('--typescript',async function () {
+    it('--typescript', async function() {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', '--typescript', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
@@ -66,7 +66,7 @@ describe('test/ts.test.js', () => {
       assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
 
-    it('--sourcemap',async function () {
+    it('--sourcemap', async function() {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', '--sourcemap', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
@@ -83,19 +83,19 @@ describe('test/ts.test.js', () => {
 
   describe('pkg.egg.typescript', () => {
     let app;
-    beforeEach(async function () {
+    beforeEach(async function() {
       fixturePath = path.join(__dirname, 'fixtures/ts-pkg');
       await utils.cleanup(fixturePath);
       const result = cp.spawnSync('npm', [ 'run', isWin ? 'windows-build' : 'build' ], { cwd: fixturePath, shell: isWin });
       assert(!result.stderr.toString());
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
       app && app.proc.kill('SIGTERM');
       await utils.cleanup(fixturePath);
     });
 
-    it('should got correct stack',async function () {
+    it('should got correct stack', async function() {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', fixturePath ]);
       // app.debug();
       app.expect('code', 0);

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -26,56 +26,56 @@ describe('test/ts.test.js', () => {
 
   describe('should display correct stack traces', () => {
     let app;
-    beforeEach(function* () {
+    beforeEach(async function () {
       fixturePath = path.join(__dirname, 'fixtures/ts');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
       const result = cp.spawnSync('npm', [ 'run', isWin ? 'windows-build' : 'build' ], { cwd: fixturePath, shell: isWin });
       assert(!result.stderr.toString());
     });
 
-    afterEach(function* () {
+    afterEach(async function () {
       app && app.proc.kill('SIGTERM');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
     });
 
-    it('--ts', function* () {
+    it('--ts',async function () {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', '--ts', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
 
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
+      const result = await httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
       assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
 
-    it('--typescript', function* () {
+    it('--typescript',async function () {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', '--typescript', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
 
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
+      const result = await httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
       assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
 
-    it('--sourcemap', function* () {
+    it('--sourcemap',async function () {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', '--sourcemap', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
 
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
+      const result = await httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
       assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });
@@ -83,28 +83,28 @@ describe('test/ts.test.js', () => {
 
   describe('pkg.egg.typescript', () => {
     let app;
-    beforeEach(function* () {
+    beforeEach(async function () {
       fixturePath = path.join(__dirname, 'fixtures/ts-pkg');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
       const result = cp.spawnSync('npm', [ 'run', isWin ? 'windows-build' : 'build' ], { cwd: fixturePath, shell: isWin });
       assert(!result.stderr.toString());
     });
 
-    afterEach(function* () {
+    afterEach(async function () {
       app && app.proc.kill('SIGTERM');
-      yield utils.cleanup(fixturePath);
+      await utils.cleanup(fixturePath);
     });
 
-    it('should got correct stack', function* () {
+    it('should got correct stack',async function () {
       app = coffee.fork(eggBin, [ 'start', '--workers=1', fixturePath ]);
       // app.debug();
       app.expect('code', 0);
 
-      yield sleep(waitTime);
+      await sleep(waitTime);
 
       assert(app.stderr === '');
       assert(app.stdout.match(/egg started on http:\/\/127\.0\.0\.1:7001/));
-      const result = yield httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
+      const result = await httpclient.request('http://127.0.0.1:7001', { dataType: 'json' });
       // console.log(result.data);
       assert(result.data.stack.includes(path.normalize('app/controller/home.ts:6:13')));
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,8 +4,8 @@ const helper = require('../lib/helper');
 const sleep = require('mz-modules/sleep');
 const isWin = process.platform === 'win32';
 
-exports.cleanup = function* (baseDir) {
-  const processList = yield helper.findNodeProcess(x => {
+exports.cleanup = async function  (baseDir) {
+  const processList = await helper.findNodeProcess(x => {
     const dir = isWin ? baseDir.replace(/\\/g, '\\\\') : baseDir;
     const prefix = isWin ? '\\"baseDir\\":\\"' : '"baseDir":"';
     return x.cmd.includes(`${prefix}${dir}`);
@@ -36,6 +36,6 @@ exports.cleanup = function* (baseDir) {
       }
     }
 
-    yield sleep('5s');
+    await sleep('5s');
   }
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,7 @@ const helper = require('../lib/helper');
 const sleep = require('mz-modules/sleep');
 const isWin = process.platform === 'win32';
 
-exports.cleanup = async function  (baseDir) {
+exports.cleanup = async function(baseDir) {
   const processList = await helper.findNodeProcess(x => {
     const dir = isWin ? baseDir.replace(/\\/g, '\\\\') : baseDir;
     const prefix = isWin ? '\\"baseDir\\":\\"' : '"baseDir":"';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
1.Drop support of Node <=6.x
2.Change generator to async function
3.CI remove Node 6 support
