### PR TITLE
feat: support pkgInfo.egg.require

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,6 +30,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: update npm
+      run: npm i -g npm
+
     - name: Install Dependencies
       run: npm i -g npminstall && npminstall
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,7 +57,7 @@ class Command extends BaseCommand {
       }
 
       // read `egg.require` from package.json
-      if (eggInfo.require && Array.isArray(eggInfo.require)) {
+      if (eggInfo && eggInfo.require && Array.isArray(eggInfo.require)) {
         execArgvObj.require = execArgvObj.require || [];
         eggInfo.require.forEach(injectScript => {
           execArgvObj.require.push(path.resolve(baseDir, injectScript));

--- a/lib/command.js
+++ b/lib/command.js
@@ -26,6 +26,12 @@ class Command extends BaseCommand {
         type: 'boolean',
         alias: [ 'ts', 'typescript' ],
       },
+
+      require: {
+        description: 'inject to execArgv --require',
+        type: 'array',
+        alias: 'r',
+      },
     };
 
     this.logger = new Logger({
@@ -38,18 +44,28 @@ class Command extends BaseCommand {
     const context = super.context;
     const { argv, execArgvObj, cwd } = context;
 
-    // read `egg.typescript` from package.json
     let baseDir = argv._[0] || cwd;
     if (!path.isAbsolute(baseDir)) baseDir = path.join(cwd, baseDir);
     const pkgFile = path.join(baseDir, 'package.json');
     if (fs.existsSync(pkgFile)) {
       const pkgInfo = require(pkgFile);
-      if (pkgInfo && pkgInfo.egg && pkgInfo.egg.typescript) {
+      const eggInfo = pkgInfo.egg;
+
+      // read `egg.typescript` from package.json
+      if (eggInfo && eggInfo.typescript) {
         argv.sourcemap = true;
       }
 
+      // read `egg.require` from package.json
+      if (eggInfo.require && Array.isArray(eggInfo.require)) {
+        execArgvObj.require = execArgvObj.require || [];
+        eggInfo.require.forEach(injectScript => {
+          execArgvObj.require.push(path.resolve(baseDir, injectScript));
+        });
+      }
+
       // read argv from eggScriptsConfig in package.json
-      if (pkgInfo && pkgInfo.eggScriptsConfig && typeof pkgInfo.eggScriptsConfig === 'object') {
+      if (pkgInfo.eggScriptsConfig && typeof pkgInfo.eggScriptsConfig === 'object') {
         for (const key in pkgInfo.eggScriptsConfig) {
           if (argv[key] == null) argv[key] = pkgInfo.eggScriptsConfig[key];
         }

--- a/test/fixtures/pkg-config/config/config.default.js
+++ b/test/fixtures/pkg-config/config/config.default.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.keys = '123456';
+
+exports.logger = {
+  level: 'WARN',
+  consoleLevel: 'WARN',
+};

--- a/test/fixtures/pkg-config/inject.js
+++ b/test/fixtures/pkg-config/inject.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('@@@ inject by pkgInfo');

--- a/test/fixtures/pkg-config/package.json
+++ b/test/fixtures/pkg-config/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "egg": {
+    "require": [
+      "./inject.js"
+    ]
+  }
+}

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -577,7 +577,11 @@ describe('test/start.test.js', () => {
         const exitEvent = awaitEvent(app.proc, 'exit');
         app.proc.kill('SIGTERM');
         const code = yield exitEvent;
-        assert(code === 0);
+        if (isWin) {
+          assert(code === null);
+        } else {
+          assert(code === 0);
+        }
       });
     });
   });

--- a/test/start.test.js
+++ b/test/start.test.js
@@ -473,6 +473,32 @@ describe('test/start.test.js', () => {
       });
     });
 
+    describe('read pkgInfo', () => {
+      let app;
+      let fixturePath;
+
+      before(function* () {
+        fixturePath = path.join(__dirname, 'fixtures/pkg-config');
+        yield utils.cleanup(fixturePath);
+      });
+
+      after(function* () {
+        app.proc.kill('SIGTERM');
+        yield utils.cleanup(fixturePath);
+      });
+
+      it('should --require', function* () {
+        app = coffee.fork(eggBin, [ 'start', '--workers=1', fixturePath ]);
+        app.debug();
+        app.expect('code', 0);
+
+        yield sleep(waitTime);
+
+        assert(app.stderr === '');
+        assert(app.stdout.match(/@@@ inject by pkgInfo/));
+      });
+    });
+
     describe('subDir as baseDir', () => {
       let app;
       const rootDir = path.join(__dirname, '..');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

support:

```js
{
  "name": "example",
  "egg": {
    "require": [
       "./inject.js"
    ]
  }
}
```

though already support [pkgInfo.eggScriptConfig.require](https://github.com/eggjs/egg-scripts/blob/05ac75a53814352f0cef94b902833cc01a81f022/lib/command.js#L69) , but it need to provide full path.

and more important is should act like egg-bin: https://github.com/eggjs/egg-bin/blob/8666e9eb9ce5016ac61af9f542b5518537a90a6b/lib/command.js#L84