### PR TITLE
fix: ps-cmd result may be truncated

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -8,7 +8,7 @@ exports.findNodeProcess = function* (filterFn) {
   const command = isWin ?
     'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId' :
     // command, cmd are alias of args, not POSIX standard, so we use args
-    'ps -eo "pid,args"';
+    'ps -wweo "pid,args"';
   const stdio = yield runScript(command, { stdio: 'pipe' });
   const processList = stdio.stdout.toString().split('\n')
     .reduce((arr, line) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
1. in some terminals, command ps result may be truncated